### PR TITLE
Update test_strings.py

### DIFF
--- a/test_strings.py
+++ b/test_strings.py
@@ -19,6 +19,9 @@ l1 = [[str(i+j) for i in range(4)]
 short_format_str = ''.join(['%s' for i in range(4)])
 result1 = ''.join(l1[-1])
 
+l_more = [str(i) for i in range(1000000)]
+result_more = ''.join(l_more)
+
 def string_concat():
     s = ''
     for part in l:
@@ -90,6 +93,25 @@ def string_array():
     return s.tostring()
 
 assert string_array() == result
+
+
+def string_cstringio_more():
+    s = cStringIO.StringIO()
+    write = s.write
+    for part in l_more:
+        write(part)
+    return s.getvalue()
+
+assert string_cstringio_more() == result_more
+
+
+def string_concat_more():
+    s = ''
+    for part in l_more:
+        s += part
+    return s
+
+assert string_concat_more() == result_more
 
 ###
 


### PR DESCRIPTION
I've just seen your talk at FOSDEM and you mentioned cStringIO wasn't that fast. I just recenlty did some performance testing with it and my conclusion was that it's only fast when it has to handle a lot of data/iterations. My guess is that it's due to many memory reallocations that the string_concat has to do.

On my machine the "boundary" is about 200k iterations. I've made the example 1M iterations so that the speedup shows its' advantage 

Timing function string_concat_more():
10 loops, best of 3: 1.94 sec per loop  

Timing function string_cstringio_more():
10 loops, best of 3: 382 msec per loop
